### PR TITLE
Remove console.log for initial build

### DIFF
--- a/ember-cli-styles-override.js
+++ b/ember-cli-styles-override.js
@@ -1,6 +1,5 @@
 function emberCliStylesOverride(app, preprocessors) {
 
-    console.log('EmberCliStylesOverride', arguments);
     if (!app.options.sprite) {
         return;
     }


### PR DESCRIPTION
So the console looks a lot cleaner when building with ember.

![screen shot](https://cloud.githubusercontent.com/assets/1079135/3795163/d4058c0e-1bb7-11e4-9e15-d82bea615a24.png)
