### PR TITLE
Remove broccoli-concat

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "homepage": "https://github.com/bguiz/broccoli-sprite",
   "dependencies": {
     "broccoli-caching-writer": "^0.4.2",
-    "broccoli-concat": "0.0.6",
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-static-compiler": "^0.1.4",
     "lodash-node": "^2.4.1",


### PR DESCRIPTION
It is no longer used as of [this](https://github.com/bguiz/broccoli-sprite/commit/c2219ee61df693b7c1b4a79f0e303042a45c3788) commit